### PR TITLE
Remove geopy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,9 +25,9 @@ before_install:
 
 install:
     - |
-      MINICONDA_URL="http://repo.continuum.io/miniconda"
+      MINICONDA_URL="https://repo.continuum.io/miniconda"
       MINICONDA_FILE="Miniconda3-latest-MacOSX-x86_64.sh"
-      curl -O "${MINICONDA_URL}/${MINICONDA_FILE}"
+      curl -L -O "${MINICONDA_URL}/${MINICONDA_FILE}"
       bash $MINICONDA_FILE -b
 
       source /Users/travis/miniconda3/bin/activate root

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -56,8 +56,18 @@ install:
 
     # Cywing's git breaks conda-build. (See https://github.com/conda-forge/conda-smithy-feedstock/pull/2.)
     - cmd: rmdir C:\cygwin /s /q
-    - appveyor DownloadFile "https://raw.githubusercontent.com/pelson/Obvious-CI/master/bootstrap-obvious-ci-and-miniconda.py"
+    - appveyor DownloadFile "https://raw.githubusercontent.com/conda-forge/conda-smithy/e976c7e84bb3c4846e7562afd1a42c4b535b51f5/bootstrap-obvious-ci-and-miniconda.py"
     - cmd: python bootstrap-obvious-ci-and-miniconda.py %CONDA_INSTALL_LOCN% %TARGET_ARCH% %CONDA_PY:~0,1% --without-obvci
+
+    # Add a hack to switch to `conda` version `4.1.12` before activating.
+    # This is required to handle a long path activation issue.
+    # Please see PR ( https://github.com/conda/conda/pull/3349 ).
+    - cmd: set "OLDPATH=%PATH%"
+    - cmd: set "PATH=%CONDA_INSTALL_LOCN%\\Scripts;%CONDA_INSTALL_LOCN%\\Library\\bin;%PATH%"
+    - cmd: conda install --yes --quiet conda=4.1.12
+    - cmd: set "PATH=%OLDPATH%"
+    - cmd: set "OLDPATH="
+
     - cmd: call %CONDA_INSTALL_LOCN%\Scripts\activate.bat
     - cmd: set PYTHONUNBUFFERED=1
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,54 +1,53 @@
 {% set version = "0.2.1" %}
 
 package:
-    name: geopandas
-    version: {{ version }}
+  name: geopandas
+  version: {{ version }}
 
 source:
-    fn: geopandas-{{ version }}.tar.gz
-    url: https://github.com/geopandas/geopandas/archive/v{{ version }}.tar.gz
-    sha256: 1e1845acbf6cf8dd2850aec9bfaa92892e462887903e3ea1abb8111e88a41206
+  fn: geopandas-{{ version }}.tar.gz
+  url: https://github.com/geopandas/geopandas/archive/v{{ version }}.tar.gz
+  sha256: 1e1845acbf6cf8dd2850aec9bfaa92892e462887903e3ea1abb8111e88a41206
 
 build:
-    number: 1
-    script: python setup.py install --single-version-externally-managed --record record.txt
+  number: 2
+  script: python setup.py install --single-version-externally-managed --record record.txt
 
 requirements:
-    build:
-        - python
-        - setuptools
-    run:
-        - python
-        - pandas
-        - pyproj
-        - shapely
-        - fiona
-        - gdal 2.1.*
-        - six
-        - rtree
-        - descartes  # [not (win and py35)]
-        - matplotlib  # [not (win and py35)]
-        - psycopg2
-        - sqlalchemy
-        - geopy 1.10.0
-        - pysal
+  build:
+    - python
+    - setuptools
+  run:
+    - python
+    - pandas
+    - pyproj
+    - shapely
+    - fiona
+    - gdal 2.1.*
+    - six
+    - rtree
+    - descartes  # [not (win and py35)]
+    - matplotlib  # [not (win and py35)]
+    - psycopg2
+    - sqlalchemy
+    - pysal
 
 test:
-    imports:
-        - geopandas
-        - geopandas.io
-    files:
-        - test_data/test.cpg
-        - test_data/test.dbf
-        - test_data/test.shp
-        - test_data/test.shx
+  imports:
+    - geopandas
+    - geopandas.io
+  files:
+    - test_data/test.cpg
+    - test_data/test.dbf
+    - test_data/test.shp
+    - test_data/test.shx
 
 about:
-    home: http://geopandas.org
-    license: BSD 3-clause
-    summary: 'Geographic pandas extensions.'
+  home: http://geopandas.org
+  license: BSD 3-clause
+  summary: 'Geographic pandas extensions.'
 
 extra:
-    recipe-maintainers:
-        - ocefpaf
-        - jorisvandenbossche
+  recipe-maintainers:
+    - ocefpaf
+    - jorisvandenbossche


### PR DESCRIPTION
@jorisvandenbossche `geopy`, in `geopandas`, it is pinned to `1.10.0`. That prevents to install newer versions along side `geopandas` and to install the awesome [OSMnx](https://github.com/gboeing/osmnx).

Since it is an optional dependency I believe we can remove it from the standard package without loss of functionality. Is that OK?