### PR TITLE
Bump to get new qt

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: 1e1845acbf6cf8dd2850aec9bfaa92892e462887903e3ea1abb8111e88a41206
 
 build:
-  number: 2
+  number: 3
   script: python setup.py install --single-version-externally-managed --record record.txt
 
 requirements:


### PR DESCRIPTION
I merged #17 mostly to get the rerendering updated but since that worked let's bump the build number and finally fix geopandas` with `matplotlib` on Python 3.5 + Windows!