### PR TITLE
depend on mpl base to avoid pulling qt

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,7 +9,7 @@ source:
   sha256: d075d2ab61a502ab92ec6b72aaf9610a1340ec24ed07264fcbdbe944b9e68954
 
 build:
-  number: 1
+  number: 2
   noarch: python
   script: "{{ PYTHON }} -m pip install . --no-deps -vv"
 
@@ -26,7 +26,7 @@ requirements:
     - six
     - rtree
     - descartes
-    - matplotlib
+    - matplotlib-base
     # We may want to re-add these two when the openssl migration is over and/or
     # when conda-forge starts using the `strict` channel option.
     # - psycopg2


### PR DESCRIPTION
Addresses https://github.com/geopandas/geopandas/issues/982#issuecomment-485407547

This will help people install `geopandas` with `matplotlib` but without `qt`.