### PR TITLE
Pyproj

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -22,7 +22,7 @@ requirements:
     - pandas >=0.23
     - shapely
     - fiona
-    - pyproj >=2.0.0
+    - pyproj >=2.2.0
     - rtree
 
 test:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -22,7 +22,7 @@ requirements:
     - pandas >=0.23
     - shapely
     - fiona
-    - pyproj
+    - pyproj >=2.0.0
     - rtree
 
 test:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,7 +9,7 @@ source:
   sha256: 19074b090ab928527193c50b383d31a259a9b84b18553562631295fa67f640bc
 
 build:
-  number: 0
+  number: 1
   noarch: python
   script: "{{ PYTHON }} -m pip install . --no-deps -vv"
 


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
This fixes an issue with incompatible packages being installed with the latest `geopandas`. 

In version `0.7.0`, `geopandas` began using the `pyproj.CRS` object. See the release blog post: https://jorisvandenbossche.github.io/blog/2020/02/11/geopandas-pyproj-crs/. 

But `pyproj.CRS` was only added in `pyproj` version `2.0.0`. See the pyproj changelog: https://pyproj4.github.io/pyproj/stable/history.html#id15.

In this change, I pin the `geopandas` recipe to require `pyproj >=2.0.0`.