### PR TITLE
 multiple output  bug

### DIFF
--- a/recipe/build_base.sh
+++ b/recipe/build_base.sh
@@ -1,1 +1,1 @@
-${PYTHON} -m pip install . --no-deps -vv
+${PYTHON} -m pip install . -vv --no-deps --no-build-isolation

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,7 +9,7 @@ source:
   sha256: b8bf70a5534588205b7a56646e2082fb1de9a03599651b3d80c99ea4c2ca08ab
 
 build:
-  number: 2
+  number: 3
   noarch: python
 
 outputs:


### PR DESCRIPTION
There is a bug in conda-build's multiple output where pip packages can get installed if we don't use those flags explicitly. We were probably in the clear here b/c all the dependencies were already available and pip won't overwrite them, but better safe than sorry.